### PR TITLE
feat(src): update verbose, safe, aggressive handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ TypeScript projects with confidence.
 - 🚀 **Modern JS/TS Support**: Supports the latest JavaScript and TypeScript
   features.
 - 📦 **Package Manager Compatibility**: Works with npm, yarn, and pnpm.
-- 🛡️ **Safe Mode**: Prevents accidental removal of essential packages.
+- 🛡️ **Safe Mode**: Prevents accidental removal of specified packages.
 - 🏗️ **Monorepo Support**: Seamlessly handles projects within monorepos.
 - ⚡ **Efficient Processing**: Utilizes parallel processing for faster analysis.
 - 🧩 **Config File Scanning**: Detects dependencies used in configuration files.
-- 🔧 **Customizable Ignoring**: Allows specifying patterns to exclude from
+- 🔧 **Customizable Ignoring**: Allows specifying directory patterns to exclude from
   scanning.
 - 🧠 **Memory Management**: Efficiently manages memory usage during analysis.
+- 🏆 **Impact Reporting**: See the impact of removing unused dependencies.
 
 ## Installation
 
@@ -67,7 +68,8 @@ depsweep
 Options:
   -v, --verbose          Display detailed usage information
   -i, --ignore <paths>   Patterns to ignore during scanning
-  --safe                 Enable safe mode to protect essential packages
+  --safe                 Enable safe mode to protect specified packages
+  -a, --aggressive       Allow removal of protected packages
   --dry-run              Show what would be removed without making changes
   --no-progress          Disable the progress bar
   -h, --help             Display help information
@@ -89,6 +91,10 @@ depsweep -i "test/**" "scripts/**"
 depsweep --dry-run
 ```
 
+## Protected Packages
+By default, a list of protected packages like `typescript` are protected to prevent accidental removal. Use
+the `-a, --aggressive` flag to override this protection. Combine with the `-s, --safe` flag to enable removal for only some protected packages.
+
 ## How It Works
 
 `depsweep` performs a comprehensive analysis of your project to identify and remove
@@ -106,13 +112,10 @@ unused dependencies:
 4. **Monorepo Awareness**: Detects monorepo structures and adjusts analysis
    accordingly. This ensures that dependencies used across multiple packages in
    a monorepo are correctly identified and not mistakenly marked as unused.
-5. **Essential Package Protection**: Prevents removal of critical packages when
-   in safe mode. This feature ensures that essential development tools and
-   libraries are not accidentally removed.
-6. **Efficient Processing**: Leverages parallel processing for faster execution.
+5. **Efficient Processing**: Leverages parallel processing for faster execution.
    By processing files in parallel, `depsweep` can analyze large codebases more
    quickly and efficiently.
-7. **Memory Management**: Monitors and manages memory usage during analysis to
+6. **Memory Management**: Monitors and manages memory usage during analysis to
    prevent crashes. This ensures that the tool can handle large projects without
    running out of memory.
 
@@ -124,7 +127,6 @@ unused dependencies:
 - ✅ Configuration Files
 - ✅ Workspace Packages
 - ✅ Binary File Detection
-- ✅ Essential Package Protection
 - ✅ Monorepo Support
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -1144,13 +1144,15 @@ async function main(): Promise<void> {
             time = await measureInstallTime(dep);
             totalInstallTime += time;
             installResults.push({ dep, time });
-            measureSpinner.text = `${MESSAGES.measuringInstallTime} (${i + 1}/${totalPackages})`;
+            measureSpinner.text = `${MESSAGES.measuringInstallTime} ${chalk.blue(`[${i + 1}/${totalPackages}]`)}`;
           } catch {
             // Ignore errors and continue
           }
         }
 
-        measureSpinner.succeed(MESSAGES.measureComplete);
+        measureSpinner.succeed(
+          `${MESSAGES.measureComplete} ${chalk.blue(`[${totalPackages}/${totalPackages}]`)}`,
+        );
         installResults.forEach((entry) =>
           console.log(`${entry.dep}: ${entry.time.toFixed(2)}s`),
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import type { Ora } from 'ora';
 import shellEscape from 'shell-escape';
 
 const MESSAGES = {
+  title: 'DepSweep 🧹',
   noPackageJson: 'No package.json found.',
   monorepoDetected: '\nMonorepo detected. Using root package.json.',
   monorepoWorkspaceDetected: '\nMonorepo workspace package detected.',
@@ -984,7 +985,9 @@ async function main(): Promise<void> {
     const projectDirectory = path.dirname(packageJsonPath);
     const context = await getPackageContext(packageJsonPath);
 
-    console.log(chalk.bold('\ndepsweep Deps Analysis'));
+    console.log(chalk.cyan(MESSAGES.title));
+
+    console.log(chalk.bold('\nDependency Analysis'));
     console.log(
       `Package.json found at: ${chalk.green(
         path.relative(process.cwd(), packageJsonPath),

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,8 @@ const traverseFunction = ((traverse as any).default || traverse) as (
   options: any,
 ) => void;
 
-// Add essential packages that should never be removed
-const ESSENTIAL_PACKAGES = new Set([
+// Add protected packages that should never be removed
+const PROTECTED_PACKAGES = new Set([
   'typescript',
   '@types/node',
   'tslib',
@@ -951,7 +951,7 @@ async function main(): Promise<void> {
       )
       .option('-v, --verbose', 'display detailed usage information')
       .option('-i, --ignore <patterns...>', 'patterns to ignore')
-      .option('-a, --aggressive', 'allow removal of essential packages')
+      .option('-a, --aggressive', 'allow removal of protected packages')
       .option(
         '-s, --safe <deps...>',
         'additional dependencies to protect from removal',
@@ -1085,13 +1085,13 @@ async function main(): Promise<void> {
       .filter((result) => !result.isUsed)
       .map((result) => result.dep);
 
-    // By default, run in safe mode (filter out essential packages)
-    // Only include essential packages if aggressive flag is set
+    // By default, run in safe mode (filter out protected packages)
+    // Only include protected packages if aggressive flag is set
     let safeUnused: string[] = [];
 
     // Create a combined set of protected packages
     const protectedPackages = new Set([
-      ...ESSENTIAL_PACKAGES,
+      ...PROTECTED_PACKAGES,
       ...(options.safe || []),
     ]);
 


### PR DESCRIPTION
This pull request includes several updates to the `README.md` and `src/index.ts` files to enhance the functionality and documentation of the `depsweep` tool. The most important changes include updating the safe mode to protect specified packages, introducing an aggressive mode for removing protected packages, and improving progress display and messaging.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R27): Updated the description of the safe mode to specify that it protects specified packages instead of essential ones. Added new options for aggressive mode and detailed the protection of packages. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R97) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R118) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127)

### Functional enhancements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L79-R80): Introduced a new `--aggressive` flag to allow the removal of protected packages and updated the `--safe` flag to protect additional specified packages. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L79-R80) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L516-L520) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L959-R958)

### Messaging and progress updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R34-L41): Added a title message for `depsweep`, improved the progress bar handling by making it optional, and updated various messages for better clarity and user experience. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R34-L41) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L989-R990) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1024-L1032) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1044-R1064) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1088-R1120) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1163-R1171) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1178-R1205)

These changes collectively improve the usability and functionality of the `depsweep` tool, making it more flexible and informative for users.