### PR TITLE
feat(src): clean up progress bar

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const MESSAGES = {
 
 export const CLI_STRINGS = {
   PROGRESS_FORMAT:
-    'Analyzing dependencies |{bar}| {currentFiles}/{totalFiles} Files | {currentDeps}/{totalDeps} Dependencies | {percentage}%',
+    'Dependency Analysis |{bar}| [{currentDeps}/{totalDeps}] {dep}',
   BAR_COMPLETE: '\u2588',
   BAR_INCOMPLETE: '\u2591',
   CLI_NAME: 'depsweep',

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,13 +182,19 @@ async function main(): Promise<void> {
     let progressBar: cliProgress.SingleBar | null = null;
     if (options.progress) {
       progressBar = new cliProgress.SingleBar({
-        format: 'Dependency Analysis |{bar}| {currentDep}',
+        format: CLI_STRINGS.PROGRESS_FORMAT,
         barCompleteChar: CLI_STRINGS.BAR_COMPLETE,
         barIncompleteChar: CLI_STRINGS.BAR_INCOMPLETE,
+        hideCursor: true,
+        clearOnComplete: false,
+        forceRedraw: true,
+        linewrap: false,
       });
       activeProgressBar = progressBar;
       progressBar.start(100, 0, {
-        currentDep: '',
+        currentDeps: 0,
+        totalDeps: dependencies.length,
+        dep: '',
       });
     }
 
@@ -213,7 +219,9 @@ async function main(): Promise<void> {
         progressBar.update(
           (analysisStepsProcessed / totalAnalysisSteps) * 100,
           {
-            currentDep: `[${totalDepsProcessed}/${dependencies.length}] ${currentDependency}`,
+            currentDeps: totalDepsProcessed,
+            totalDeps: dependencies.length,
+            dep: currentDependency,
           },
         );
       }
@@ -253,9 +261,10 @@ async function main(): Promise<void> {
     }
 
     if (progressBar) {
-      // Force final update to ensure 100% is shown
       progressBar.update(100, {
-        currentDep: `[${totalDepsProcessed}/${dependencies.length}] ${chalk.green('✔')}`,
+        currentDeps: dependencies.length,
+        totalDeps: dependencies.length,
+        dep: chalk.green('✓'),
       });
       progressBar.stop();
     }


### PR DESCRIPTION
This pull request includes changes to the progress bar format and its usage in the dependency analysis tool. The most important changes include updating the progress bar format string, modifying the progress bar initialization and update logic, and ensuring the final update correctly reflects the completion status.

Changes to progress bar format and usage:

* [`src/constants.ts`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L24-R24): Updated the `PROGRESS_FORMAT` string in `CLI_STRINGS` to a new format that includes `currentDeps`, `totalDeps`, and `dep` instead of `currentFiles`, `totalFiles`, and `percentage`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L185-R197): Modified the progress bar initialization to use the updated `PROGRESS_FORMAT` and added new options such as `hideCursor`, `clearOnComplete`, `forceRedraw`, and `linewrap`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L216-R224): Updated the progress bar during the analysis process to use `currentDeps`, `totalDeps`, and `dep` instead of `currentDep`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L256-R267): Ensured the final update to the progress bar shows 100% completion with the correct values for `currentDeps`, `totalDeps`, and `dep`.